### PR TITLE
Stopped tunnels from closing gracefully

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,12 +34,12 @@ def server(tunnel_host, tunnel_port):
     def location(sid, data):
         la, lo = list(map(lambda x: float(x), data.split(',')))
         clients[sid][1].simulate_location(la, lo)
-
-    @sio.event
-    def disconnect(sid):
-        clients[sid][1].stop()
-        clients[sid][0].service.close()
-        clients.pop(sid)
+# Uncomment the following to allow device to disconnect gracefully (returning location back to normal without restart)
+#    @sio.event
+#    def disconnect(sid):
+#        clients[sid][1].stop()
+#        clients[sid][0].service.close()
+#        clients.pop(sid)
 
     s = eventlet.listen(('localhost', 3000))
     [ip, port] = s.getsockname()


### PR DESCRIPTION
When the iDevice is unplugged, the tunnels gracefully close which causes the device's location to return to normal within 5-10 minutes. I've seen multiple issues relating to that behavior, so for ease of use I've just commented out the disconnect function so that locations persist by default